### PR TITLE
PAY-6539

### DIFF
--- a/audit.json
+++ b/audit.json
@@ -6,6 +6,7 @@
   "10010_Cookie No HttpOnly Flag_http://bar-api-aat.service.core-compute-aat.internal/v2/api-docs_GET":"ignore",
   "10096_Timestamp Disclosure - Unix_http://bar-api-aat.service.core-compute-aat.internal/v2/api-docs_GET":"ignore",
   "10054_Cookie without SameSite Attribute_http://bar-api-aat.service.core-compute-aat.internal/v2/api-docs_GET":"ignore",
+  "10112_Session Management Response Identified_http://bar-api-aat.service.core-compute-aat.internal/v2/api-docs_GET":"ignore",
   "10010_Cookie No HttpOnly Flag_http://bar-api-aat.service.core-compute-aat.internal_GET":"ignore",
   "10010_Cookie No HttpOnly Flag_http://bar-api-aat.service.core-compute-aat.internal/_GET":"ignore",
   "10010_Cookie No HttpOnly Flag_http://bar-api-aat.service.core-compute-aat.internal/robots.txt_GET":"ignore",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PAY-6539


### Change description ###
A suppression of the ZA Proxy informational messaage that is breaking the build at the security scan.
The message clearly states "Solution: <p>This is an informational alert rather than a vulnerability and so there is nothing to fix." so setting to ignore.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
